### PR TITLE
Agregar main.py y README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# WhisperPy
+
+Aplicación gráfica básica para pruebas con Whisper.
+
+## Requisitos
+
+- Python 3.8 o superior
+- Biblioteca `requests`
+- (Opcional) crear un entorno virtual llamado `venv` en la carpeta del programa
+
+## Ejecución
+
+1. Instalar las dependencias (preferiblemente en un entorno virtual):
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # En Windows: venv\Scripts\activate
+   pip install requests
+   ```
+
+2. Ejecutar la aplicación:
+   ```bash
+   python main.py
+   ```
+   Si `main.py` detecta la carpeta `venv` y no se está dentro de un entorno
+   virtual, reiniciará el programa utilizando ese entorno.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import tkinter as tk
+
+from whisper_v1 import WhisperGUI
+
+
+def ensure_venv():
+    """Reejecuta el script usando la venv local si existe y no estamos en una."""
+    # Comprobamos si no se ejecuta ya en un entorno virtual
+    in_venv = sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    if in_venv:
+        return
+
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    venv_dir = os.path.join(base_dir, "venv")
+    if not os.path.isdir(venv_dir):
+        return
+
+    if os.name == "nt":
+        python_exec = os.path.join(venv_dir, "Scripts", "python.exe")
+    else:
+        python_exec = os.path.join(venv_dir, "bin", "python")
+
+    if os.path.exists(python_exec):
+        os.execv(python_exec, [python_exec] + sys.argv)
+
+
+if __name__ == "__main__":
+    ensure_venv()
+    root = tk.Tk()
+    app = WhisperGUI(root)
+    root.mainloop()


### PR DESCRIPTION
## Summary
- add an executable `main.py` that starts `WhisperGUI`
- detect a local `venv` and re-execute using it if not already in a virtual env
- add README with usage instructions and requirements

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6870062cec148322b0ff05dd73375587