### PR TITLE
Add transcriber module for Whisper execution

### DIFF
--- a/transcriber.py
+++ b/transcriber.py
@@ -1,0 +1,65 @@
+import os
+import subprocess
+
+
+def transcribe_audio(audio_path, model, language, env_path=None):
+    """Transcribe an audio file using Whisper.
+
+    Parameters
+    ----------
+    audio_path : str
+        Path to the audio file.
+    model : str
+        Whisper model to use.
+    language : str
+        Language of the audio.
+    env_path : str, optional
+        Path to a virtual environment whose Python interpreter should be
+        used to run Whisper. If not provided, the system's default
+        interpreter will be used.
+
+    Returns
+    -------
+    str
+        Path to the generated transcription file.
+
+    Raises
+    ------
+    RuntimeError
+        If Whisper execution fails or the output file is not created.
+    """
+    audio_path = os.path.abspath(audio_path)
+    output_dir = os.path.dirname(audio_path)
+    base_name = os.path.splitext(os.path.basename(audio_path))[0]
+    default_output = os.path.join(output_dir, f"{base_name}.txt")
+    target_output = os.path.join(output_dir, f"{base_name}_transc.txt")
+
+    if env_path:
+        python_exe = os.path.join(env_path, "bin", "python")
+        cmd = [python_exe, "-m", "whisper", audio_path,
+               "--model", model,
+               "--language", language,
+               "--output_format", "txt",
+               "--output_dir", output_dir]
+    else:
+        cmd = ["whisper", audio_path,
+               "--model", model,
+               "--language", language,
+               "--output_format", "txt",
+               "--output_dir", output_dir]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        msg = e.stderr.strip() or e.stdout.strip() or str(e)
+        raise RuntimeError(f"Error al ejecutar Whisper: {msg}")
+
+    if not os.path.exists(default_output):
+        raise RuntimeError(f"No se encontró el archivo de salida esperado: {default_output}")
+
+    try:
+        os.replace(default_output, target_output)
+    except Exception as e:
+        raise RuntimeError(f"Error al mover el archivo de salida: {e}")
+
+    return target_output


### PR DESCRIPTION
## Summary
- introduce `transcriber.py` with `transcribe_audio` function
- allow optional virtualenv interpreter
- generate transcript file `<audio>_transc.txt` and report errors

## Testing
- `python -m py_compile transcriber.py whisper_v1.py`

------
https://chatgpt.com/codex/tasks/task_e_6870062ba4808322af3bb152740068f4