### PR TITLE
Add model manager module with network fallback

### DIFF
--- a/model_manager.py
+++ b/model_manager.py
@@ -1,0 +1,61 @@
+import os
+from typing import Dict
+import requests
+
+class WhisperModelManager:
+    """Gestiona los modelos de Whisper disponibles."""
+
+    FALLBACK_MODELS: Dict[str, str] = {
+        "tiny": "Muy rápido, baja precisión (~39 MB) - Ideal para pruebas rápidas",
+        "base": "Rápido con precisión media (~74 MB) - Uso general",
+        "small": "Equilibrio entre velocidad y precisión (~244 MB) - Proyectos medianos",
+        "medium": "Alta precisión, más lento (~769 MB) - Transcripciones detalladas",
+        "large": "Máxima precisión, muy lento (~1.5 GB) - Mejor para audios complejos",
+    }
+
+    @staticmethod
+    def obtener_modelos_online() -> Dict[str, str]:
+        """Obtiene la lista de modelos desde HuggingFace."""
+        try:
+            url = "https://huggingface.co/api/models?search=openai/whisper"
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            modelos = {
+                m["id"].replace("openai/whisper-", ""): WhisperModelManager.FALLBACK_MODELS.get(
+                    m["id"].split("-")[-1], "Modelo disponible"
+                )
+                for m in data
+                if "openai/whisper-" in m.get("id", "")
+            }
+            return modelos or WhisperModelManager.FALLBACK_MODELS
+        except Exception:
+            # Ante cualquier problema de red se devuelven los modelos por defecto
+            return WhisperModelManager.FALLBACK_MODELS
+
+    @staticmethod
+    def _modelos_locales() -> Dict[str, str]:
+        """Busca modelos disponibles localmente en el directorio 'models'."""
+        modelos = {}
+        directorio = os.path.expanduser("models")
+        if os.path.isdir(directorio):
+            for archivo in os.listdir(directorio):
+                if archivo.endswith(".pt"):
+                    nombre = os.path.splitext(archivo)[0]
+                    modelos[nombre] = f"Modelo local disponible ({archivo})"
+        return modelos
+
+    @classmethod
+    def get_available_models(cls) -> Dict[str, str]:
+        """Combina modelos locales con los remotos.
+
+        Si ocurre un error de red al consultar los remotos se devuelven los
+        modelos de :data:`FALLBACK_MODELS`.
+        """
+        locales = cls._modelos_locales()
+        try:
+            remotos = cls.obtener_modelos_online()
+        except Exception:
+            remotos = cls.FALLBACK_MODELS
+        modelos = {**remotos, **locales}
+        return modelos or cls.FALLBACK_MODELS

--- a/whisper_v1.py
+++ b/whisper_v1.py
@@ -4,33 +4,10 @@ import sys
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 import threading
-import requests
-import json
-from typing import Dict
+from model_manager import WhisperModelManager
 import shlex
 import wave
 
-class WhisperModelManager:
-    FALLBACK_MODELS = {
-        "tiny": "Muy rápido, baja precisión (~39 MB)",
-        "base": "Rápido, precisión media (~74 MB)",
-        "small": "Compromiso velocidad/precisión (~244 MB)",
-        "medium": "Precisión alta, más lento (~769 MB)",
-        "large": "Máxima precisión, muy lento (~1.5 GB)",
-    }
-
-    @staticmethod
-    def obtener_modelos_online() -> Dict[str, str]:
-        try:
-            url = "https://huggingface.co/api/models?search=openai/whisper"
-            resp = requests.get(url, timeout=10)
-            resp.raise_for_status()
-            data = resp.json()
-            modelos = {m['id'].replace('openai/whisper-', ''): WhisperModelManager.FALLBACK_MODELS.get(m['id'].split('-')[-1], "Modelo disponible")
-                      for m in data if 'openai/whisper-' in m.get('id', '')}
-            return modelos or WhisperModelManager.FALLBACK_MODELS
-        except Exception:
-            return WhisperModelManager.FALLBACK_MODELS
 
 class WhisperGUI:
     def __init__(self, master):


### PR DESCRIPTION
## Summary
- extract `WhisperModelManager` to new `model_manager.py`
- expand model descriptions
- add local model discovery and `get_available_models`
- update `whisper_v1.py` to import the new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870062a5a2c8322bc7ee9a10cca47be