### PR TITLE
Mejora de gestión de entorno y mensajes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /venv/*
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Aplicación gráfica básica para pruebas con Whisper.
 
 - Python 3.8 o superior
 - Bibliotecas `requests` y `openai-whisper`
-- (Opcional) crear un entorno virtual llamado `venv` en la carpeta del programa
+- (Opcional) crear un entorno virtual llamado `WhispVenv` en la carpeta del programa
 
 ## Ejecución
 
 1. Instalar las dependencias (preferiblemente en un entorno virtual):
    ```bash
-   python -m venv venv
-   source venv/bin/activate  # En Windows: venv\Scripts\activate
+   python -m venv WhispVenv
+   source WhispVenv/bin/activate  # En Windows: WhispVenv\Scripts\activate
    pip install requests openai-whisper
    ```
 
@@ -21,8 +21,8 @@ Aplicación gráfica básica para pruebas con Whisper.
    ```bash
    python main.py
    ```
-   Si `main.py` detecta la carpeta `venv` y no se está dentro de un entorno
-   virtual, reiniciará el programa utilizando ese entorno.
+   Al ejecutarse, `main.py` creará si es necesario el entorno `WhispVenv`
+   y reiniciará la aplicación dentro de él.
 
 Al abrir la aplicación, el desplegable de modelos indica con "(local)" los
 modelos que ya se encuentran descargados en la carpeta `models`.
@@ -33,9 +33,9 @@ modelos que ya se encuentran descargados en la carpeta `models`.
 
 El proyecto se divide en varios módulos principales:
 
-- **`main.py`**: punto de entrada. Comprueba si existe un directorio
-  `venv` y relanza el programa con ese intérprete si es necesario. Luego
-  crea la ventana principal e inicia la interfaz gráfica.
+- **`main.py`**: punto de entrada. Crea (si es necesario) el directorio
+  `WhispVenv`, instala las dependencias y relanza el programa con ese
+  intérprete antes de mostrar la interfaz gráfica.
 - **`gui.py`**: define la clase `WhisperGUI`, que construye la interfaz
   basada en Tkinter. Gestiona la selección de archivos y opciones y lanza
   la transcripción en un hilo para evitar bloqueos.
@@ -52,8 +52,8 @@ El proyecto se divide en varios módulos principales:
 
 ### Clases y funciones destacadas
 
-- **`ensure_venv()`** (`main.py`): verifica si se está ejecutando dentro
-  del entorno virtual e intenta relanzar el programa en la venv local.
+- **`prepare_env()`** (`main.py`): prepara el entorno `WhispVenv`,
+  instalando dependencias y relanzando la aplicación dentro de él.
 - **`WhisperGUI`** (`gui.py`): interfaz con métodos para seleccionar
   archivos (`seleccionar_archivo`), iniciar la tarea de transcripción
   (`iniciar_transcripcion`) y manejar el resultado.

--- a/env_manager.py
+++ b/env_manager.py
@@ -10,6 +10,7 @@ class EnvironmentManager:
     def create_env(self, path: str) -> None:
         """Create a virtual environment if it does not already exist."""
         if not os.path.isdir(path):
+            print(f"Creando entorno virtual en: {path}")
             venv.create(path, with_pip=True)
 
     def install_dependencies(self, env_path: str, packages: List[str]) -> None:
@@ -17,5 +18,6 @@ class EnvironmentManager:
         if not packages:
             return
         python_exe = os.path.join(env_path, 'Scripts', 'python.exe') if os.name == 'nt' else os.path.join(env_path, 'bin', 'python')
+        print("Instalando dependencias...")
         cmd = [python_exe, '-m', 'pip', 'install', *packages]
         subprocess.check_call(cmd)

--- a/gui.py
+++ b/gui.py
@@ -17,7 +17,6 @@ class WhisperGUI:
         master.geometry("700x500")
 
         self.file_path = tk.StringVar()
-        self.usar_entorno = tk.BooleanVar(value=False)
         self.modelo = tk.StringVar(value="base")
         self.idioma = tk.StringVar(value="es")
 
@@ -52,7 +51,6 @@ class WhisperGUI:
         ttk.Label(config_frame, text="Idioma:").pack(side=tk.LEFT)
         self.combo_idioma = ttk.Combobox(config_frame, textvariable=self.idioma, values=self.IDIOMAS, width=5)
         self.combo_idioma.pack(side=tk.LEFT, padx=5)
-        ttk.Checkbutton(config_frame, text="Usar entorno", variable=self.usar_entorno).pack(side=tk.LEFT, padx=5)
 
         ttk.Button(cont, text="Transcribir", command=self.iniciar_transcripcion).pack(pady=10)
 
@@ -92,9 +90,8 @@ class WhisperGUI:
         modelo = self._model_map.get(seleccionado, seleccionado)
         idioma = self.idioma.get() or None
         try:
-            self._append_message("Transcribiendo...")
-            env_path = os.path.join(os.getcwd(), "venv") if self.usar_entorno.get() else None
-            nombre_salida = transcribe_audio(ruta, modelo, idioma or "", env_path)
+            self._append_message("Iniciando transcripción...")
+            nombre_salida = transcribe_audio(ruta, modelo, idioma or "", status_cb=self._append_message)
             self._append_message(f"Transcripción completada: {nombre_salida}")
         except Exception as e:
             self._append_message(f"Error: {e}")

--- a/main.py
+++ b/main.py
@@ -2,32 +2,32 @@ import os
 import sys
 import tkinter as tk
 
+from env_manager import EnvironmentManager
 from gui import WhisperGUI
 
+ENV_NAME = "WhispVenv"
 
-def ensure_venv():
-    """Reejecuta el script usando la venv local si existe y no estamos en una."""
-    # Comprobamos si no se ejecuta ya en un entorno virtual
-    in_venv = sys.prefix != getattr(sys, "base_prefix", sys.prefix)
-    if in_venv:
-        return
 
+def prepare_env() -> str:
+    """Ensure the WhispVenv environment exists and relaunch under it."""
     base_dir = os.path.dirname(os.path.abspath(__file__))
-    venv_dir = os.path.join(base_dir, "venv")
-    if not os.path.isdir(venv_dir):
-        return
+    env_path = os.path.join(base_dir, ENV_NAME)
+    manager = EnvironmentManager()
+    manager.create_env(env_path)
+    manager.install_dependencies(env_path, ["openai-whisper", "requests"])
 
-    if os.name == "nt":
-        python_exec = os.path.join(venv_dir, "Scripts", "python.exe")
-    else:
-        python_exec = os.path.join(venv_dir, "bin", "python")
-
-    if os.path.exists(python_exec):
+    running_env = os.path.abspath(sys.prefix)
+    target_env = os.path.abspath(env_path)
+    if running_env != target_env:
+        python_exec = os.path.join(env_path, "Scripts", "python.exe") if os.name == "nt" else os.path.join(env_path, "bin", "python")
+        print("Reiniciando aplicación en el entorno virtual...")
         os.execv(python_exec, [python_exec] + sys.argv)
+
+    return env_path
 
 
 if __name__ == "__main__":
-    ensure_venv()
+    prepare_env()
     root = tk.Tk()
     app = WhisperGUI(root)
     root.mainloop()


### PR DESCRIPTION
## Summary
- crear y usar siempre el entorno `WhispVenv` al iniciar la app
- mostrar mensajes informativos durante la creación del entorno y la instalación de dependencias
- simplificar la GUI eliminando la casilla de 'Usar entorno' y mostrando mensajes de progreso
- informar si es necesario descargar el modelo al transcribir
- actualizar documentación y gitignore

## Testing
- `python -m py_compile env_manager.py gui.py main.py model_manager.py transcriber.py`


------
https://chatgpt.com/codex/tasks/task_e_6870b6f9b05c8322ac821e1420782cbd