### PR TITLE
Improve environment dependency checks

### DIFF
--- a/env_manager.py
+++ b/env_manager.py
@@ -17,7 +17,34 @@ class EnvironmentManager:
         """Install the given packages into the virtual environment."""
         if not packages:
             return
-        python_exe = os.path.join(env_path, 'Scripts', 'python.exe') if os.name == 'nt' else os.path.join(env_path, 'bin', 'python')
-        print("Instalando dependencias...")
-        cmd = [python_exe, '-m', 'pip', 'install', *packages]
+
+        python_exe = os.path.join(
+            env_path,
+            "Scripts",
+            "python.exe",
+        ) if os.name == "nt" else os.path.join(env_path, "bin", "python")
+
+        print("Verificando dependencias...")
+        to_install: List[str] = []
+
+        for pkg in packages:
+            try:
+                subprocess.run(
+                    [python_exe, "-m", "pip", "show", pkg],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=True,
+                )
+                print(f"  '{pkg}' ya está instalado")
+            except subprocess.CalledProcessError:
+                print(f"  '{pkg}' no está instalado")
+                to_install.append(pkg)
+
+        if not to_install:
+            print("Todas las dependencias están satisfechas.")
+            return
+
+        print(f"Instalando dependencias: {' '.join(to_install)}")
+        cmd = [python_exe, "-m", "pip", "install", *to_install]
         subprocess.check_call(cmd)
+        print("Instalación completada")


### PR DESCRIPTION
## Summary
- avoid reinstalling packages already present in the virtualenv
- print detailed messages during dependency checks

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c233c6608322b2be318b7b9f5cf1