### PR TITLE
Add empty transcription validation

### DIFF
--- a/transcriber.py
+++ b/transcriber.py
@@ -78,4 +78,7 @@ def transcribe_audio(audio_path, model, language, env_path=None, status_cb=None)
     except Exception as e:
         raise RuntimeError(f"Error al mover el archivo de salida: {e}")
 
+    if not os.path.exists(target_output) or os.path.getsize(target_output) <= 0:
+        raise RuntimeError('Transcripción vacía')
+
     return target_output


### PR DESCRIPTION
## Summary
- ensure the transcription file exists and is non-empty after moving it

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6870c21cfd408322966e331e0d4c48de