### PR TITLE
Update README dependency and model info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # WhisperPy
 
 Aplicación gráfica básica para pruebas con Whisper.
+Incluye un registro de mensajes mejorado para seguir el proceso de
+transcripción y la gestión de modelos.
 
 ## Requisitos
 
@@ -16,16 +18,20 @@ Aplicación gráfica básica para pruebas con Whisper.
    source WhispVenv/bin/activate  # En Windows: WhispVenv\Scripts\activate
    pip install requests openai-whisper
    ```
+   Estas dependencias también se instalarán automáticamente desde
+   `main.py` si no se encuentran presentes.
 
 2. Ejecutar la aplicación:
    ```bash
    python main.py
    ```
-   Al ejecutarse, `main.py` creará si es necesario el entorno `WhispVenv`
-   y reiniciará la aplicación dentro de él.
+   Al ejecutarse, `main.py` creará si es necesario el entorno `WhispVenv`,
+   instalará únicamente las dependencias que falten y reiniciará la
+   aplicación dentro de él.
 
 Al abrir la aplicación, el desplegable de modelos indica con "(local)" los
-modelos que ya se encuentran descargados en la carpeta `models`.
+modelos que ya se encuentran descargados en la carpeta `models` o en
+`~/.cache/whisper`.
 
 ## Guía para desarrolladores
 
@@ -34,15 +40,15 @@ modelos que ya se encuentran descargados en la carpeta `models`.
 El proyecto se divide en varios módulos principales:
 
 - **`main.py`**: punto de entrada. Crea (si es necesario) el directorio
-  `WhispVenv`, instala las dependencias y relanza el programa con ese
-  intérprete antes de mostrar la interfaz gráfica.
+  `WhispVenv`, instala solo las dependencias faltantes y relanza el programa
+  con ese intérprete antes de mostrar la interfaz gráfica.
 - **`gui.py`**: define la clase `WhisperGUI`, que construye la interfaz
   basada en Tkinter. Gestiona la selección de archivos y opciones y lanza
   la transcripción en un hilo para evitar bloqueos.
 - **`model_manager.py`**: incluye la clase `WhisperModelManager` que
   obtiene la lista de modelos remotos y detecta modelos locales en la
-  carpeta `models`. La GUI marca como "(local)" aquellos modelos ya
-  descargados.
+  carpeta `models` o en `~/.cache/whisper`. La GUI marca como "(local)"
+  aquellos modelos ya descargados.
 - **`transcriber.py`**: contiene la función `transcribe_audio` encargada de
   invocar la CLI de Whisper y manejar los archivos de salida. Si no se
   indica un entorno virtual, utiliza el mismo intérprete de Python que
@@ -53,7 +59,8 @@ El proyecto se divide en varios módulos principales:
 ### Clases y funciones destacadas
 
 - **`prepare_env()`** (`main.py`): prepara el entorno `WhispVenv`,
-  instalando dependencias y relanzando la aplicación dentro de él.
+  instalando solo las dependencias ausentes y relanzando la aplicación
+  dentro de él.
 - **`WhisperGUI`** (`gui.py`): interfaz con métodos para seleccionar
   archivos (`seleccionar_archivo`), iniciar la tarea de transcripción
   (`iniciar_transcripcion`) y manejar el resultado.
@@ -63,8 +70,8 @@ El proyecto se divide en varios módulos principales:
 - **`transcribe_audio()`** (`transcriber.py`): ejecuta Whisper mediante
   `subprocess`, mueve el archivo de salida y devuelve la ruta final.
 - **`EnvironmentManager`** (`env_manager.py`): ofrece `create_env` para
-  crear un entorno virtual y `install_dependencies` para instalar paquetes
-  en él.
+  crear un entorno virtual y `install_dependencies` para instalar solo los
+  paquetes que no estén presentes.
 
 Cada módulo está pensado para ser sencillo y fácilmente ampliable. Las
 funciones y clases mencionadas son el punto de extensión principal del


### PR DESCRIPTION
## Summary
- document improved logging
- explain that dependencies are installed only if missing
- note models in ~/.cache/whisper are marked as local

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6870c20eb5008322aa9e1a59021369cd