### PR TITLE
Refactor path handling with pathlib

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tkinter as tk
 import logging
+from pathlib import Path
 from typing import List
 
 from env_manager import EnvironmentManager
@@ -22,20 +23,24 @@ class BufferHandler(logging.Handler):
 
 def prepare_env() -> str:
     """Ensure the WhispVenv environment exists and relaunch under it."""
-    base_dir = os.path.dirname(os.path.abspath(__file__))
-    env_path = os.path.join(base_dir, ENV_NAME)
+    base_dir = Path(__file__).resolve().parent
+    env_path = base_dir / ENV_NAME
     manager = EnvironmentManager()
     manager.create_env(env_path)
     manager.install_dependencies(env_path, ["openai-whisper", "requests"])
 
-    running_env = os.path.abspath(sys.prefix)
-    target_env = os.path.abspath(env_path)
+    running_env = Path(sys.prefix).resolve()
+    target_env = env_path.resolve()
     if running_env != target_env:
-        python_exec = os.path.join(env_path, "Scripts", "python.exe") if os.name == "nt" else os.path.join(env_path, "bin", "python")
+        python_exec = (
+            env_path / "Scripts" / "python.exe"
+            if os.name == "nt"
+            else env_path / "bin" / "python"
+        )
         logger.info("Reiniciando aplicación en el entorno virtual...")
-        os.execv(python_exec, [python_exec] + sys.argv)
+        os.execv(str(python_exec), [str(python_exec)] + sys.argv)
 
-    return env_path
+    return str(env_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_transcriber_paths.py
+++ b/tests/test_transcriber_paths.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import subprocess
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from transcriber import transcribe_audio
+
+
+def fake_run(cmd, capture_output=True, text=True, encoding='utf-8', check=True):
+    # Simulate whisper by creating output file
+    output_dir = Path(cmd[cmd.index('--output_dir') + 1])
+    audio_index = cmd.index('whisper') + 1
+    audio_path = Path(cmd[audio_index])
+    default_output = output_dir / f"{audio_path.stem}.txt"
+    default_output.write_text('dummy')
+    return subprocess.CompletedProcess(cmd, 0, stdout='ok', stderr='')
+
+
+def test_transcriber_handles_space_in_path(tmp_path):
+    space_dir = tmp_path / "dir with space"
+    space_dir.mkdir()
+    audio_file = space_dir / "audio.wav"
+    audio_file.write_text("fake")
+
+    with mock.patch('subprocess.run', side_effect=fake_run):
+        result = transcribe_audio(str(audio_file), model='base', language='en')
+
+    assert Path(result).exists()
+    assert Path(result).parent == space_dir


### PR DESCRIPTION
## Summary
- use `pathlib.Path` for all path manipulations
- ensure subprocess calls use lists of args
- add regression test to check transcriber with paths containing spaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870de36ee508322b8de7b18373c5aba